### PR TITLE
Incorporate jruere/multiprocessing-logging changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This simple module implements a `Handler` that when set on the root
 `Logger` will handle tunneling the records to the main process so that
 they are handled correctly.
 
-It's currently tested in Linux and Python 2.7, 3.3+, pypy & pypy3.
+It's currently tested in Linux and Python 2.7, 3.3+ & pypy.
+Pypy3 hangs on the tests so I don't recommend using it.
 
 It does not work on Windows and I believe it could not work.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ This simple module implements a `Handler` that when set on the root
 `Logger` will handle tunneling the records to the main process so that
 they are handled correctly.
 
-It's currently tested in Linux and Python 2.7, 3.3+ & pypy.
+It's currently tested in Linux and Python 2.7 & 3.3+.
+
 Pypy3 hangs on the tests so I don't recommend using it.
+
+Pypy has synchronization issues.
 
 It does not work on Windows and I believe it could not work.
 

--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -12,8 +12,7 @@ import traceback
 try:
     import queue
 except ImportError:
-    # Python 2.0.
-    import Queue as queue
+    import Queue as queue  # Python 2.
 
 
 __version__ = '0.2.6'

--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -15,7 +15,7 @@ except ImportError:
     import Queue as queue  # Python 2.
 
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 
 def install_mp_handler(logger=None):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: POSIX',
     ],
     keywords="multiprocessing logging logger handler",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='multiprocessing-logging',
-    version='0.2.6',
+    version='0.2.7',
     description='Logger for multiprocessing applications',
     url='https://github.com/jruere/multiprocessing-logging',
     license="LGPLv3",
@@ -31,4 +31,5 @@ setup(
     py_modules=['multiprocessing_logging'],
     platforms=["POSIX"],
     test_suite="tests",
+    tests_require=["mock~=2.0.0 ; python_version < '3.3'"],
 )

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,7 +8,8 @@ python:
   - "3.5"
   - "3.6"
   - pypy
-  - pypy3
+  # Hangs on tests.
+  # - pypy3
 
 before_install:
   - pip install --upgrade pip setuptools

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,8 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - pypy
-# Hangs on nose2, for some reason.
-#  - pypy3
+  - pypy3
 
 before_install:
   - pip install --upgrade pip setuptools
@@ -21,7 +20,7 @@ before_script:
 
 script:
   - nose2
-  - 'which python && coverage run --branch -m unittest discover'
+  - 'which python && coverage run --branch setup.py test'
   - 'which python && coverage xml -o shippable/codecoverage/coverage.xml'
 
 #after_success:

--- a/shippable.yml
+++ b/shippable.yml
@@ -13,7 +13,7 @@ python:
 
 before_install:
   - pip install --upgrade pip setuptools
-  - pip install nose2 coverage
+  - pip install nose2 coverage mock
 
 before_script:
   - mkdir -p shippable/testresults
@@ -21,7 +21,7 @@ before_script:
 
 script:
   - nose2
-  - 'which python && coverage run --branch setup.py test'
+  - 'which python && coverage run --branch -m unittest discover'
   - 'which python && coverage xml -o shippable/codecoverage/coverage.xml'
 
 #after_success:

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,7 +7,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - pypy
+  # Has synchronization issues.
+  # - pypy
   # Hangs on tests.
   # - pypy3
 

--- a/tests/test_multiprocessing_logging.py
+++ b/tests/test_multiprocessing_logging.py
@@ -82,7 +82,7 @@ class WhenMultipleProcessesLogRecords(unittest.TestCase):
         logger.info("Workers started.")
 
         for proc in procs:
-            proc.join(2)  # This is to avoid hangs in Pypy3.
+            proc.join()
         logger.info("Workers done.")
 
         subject.close()

--- a/tests/test_multiprocessing_logging.py
+++ b/tests/test_multiprocessing_logging.py
@@ -82,7 +82,7 @@ class WhenMultipleProcessesLogRecords(unittest.TestCase):
         logger.info("Workers started.")
 
         for proc in procs:
-            proc.join()
+            proc.join(2)  # This is to avoid hangs in Pypy3.
         logger.info("Workers done.")
 
         subject.close()

--- a/tests/test_multiprocessing_logging.py
+++ b/tests/test_multiprocessing_logging.py
@@ -76,7 +76,6 @@ class WhenMultipleProcessesLogRecords(unittest.TestCase):
         logger.info("Starting workers...")
         procs = [mp.Process(target=worker, args=(wid, logger)) for wid in range(100)]
         for proc in procs:
-            proc.daemon = True
             proc.start()
 
         logger.info("Workers started.")
@@ -130,7 +129,6 @@ class WhenMultipleProcessesLogRecords(unittest.TestCase):
         logger.info("Starting workers...")
         procs = [mp.Process(target=worker, args=(wid, logger)) for wid in range(2)]
         for proc in procs:
-            proc.daemon = True
             proc.start()
         logger.info("Workers started.")
 

--- a/tests/test_multiprocessing_logging.py
+++ b/tests/test_multiprocessing_logging.py
@@ -14,7 +14,7 @@ from io import StringIO
 try:
     from unittest import mock
 except ImportError:
-    mock = None
+    import mock  # Python 2.
 
 from multiprocessing_logging import install_mp_handler, MultiProcessingHandler
 
@@ -32,9 +32,6 @@ class InstallHandlersTest(unittest.TestCase):
         self.assertIs(wrapper_handler.sub_handler, self.handler)
 
     def test_when_no_logger_is_specified_then_it_uses_the_root_logger(self):
-        if not mock:
-            self.skipTest('unittest.mock is not available')
-
         with mock.patch('logging.getLogger') as getLogger:
             getLogger.return_value = self.logger
 
@@ -47,9 +44,6 @@ class InstallHandlersTest(unittest.TestCase):
         self.assertIs(wrapper_handler.sub_handler, self.handler)
 
     def test_when_a_logger_is_passed_then_it_does_not_change_the_root_logger(self):
-        if not mock:
-            self.skipTest('unittest.mock is not available')
-
         with mock.patch('logging.getLogger') as getLogger:
             install_mp_handler(self.logger)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3
+# pypy3 hangs.
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@
 
 [tox]
 # pypy3 hangs.
-envlist = py27, py34, py35, py36, pypy
+# pypy has synchronization issues.
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION

- Fixes incorrect comment.
- Adds test dependency on mock for Python <3.3  …
Now all tests can run on all supported versions of Python.
Also, bumps version.
- Adds hack to tests for Pypy3.
- Removes Pypy3 from CI and mentions that it hangs in the README.
- Processes in tests do not need to be daemons  …
They are joined.
- Reverts how tests are run in Shippable and install mock  …
mock is needed by Python 2 but will not hurt the rest.
- Removes Pypy from CI & mentions in the README that it's not recommended.